### PR TITLE
Fix Automatic Proxy Configuration protocol for OSX 10.13

### DIFF
--- a/mcs/class/System/System.Net/MacProxy.cs
+++ b/mcs/class/System/System.Net/MacProxy.cs
@@ -688,6 +688,24 @@ namespace Mono.Net
 			if (type == kCFProxyTypeSOCKS)
 				return CFProxyType.SOCKS;
 			
+			//in OSX 10.13 pointer comparison didn't work for kCFProxyTypeAutoConfigurationURL
+			var typeString = CFString.AsString(type);
+			switch (typeString)                 
+			{                                   
+				case "kCFProxyTypeAutoConfigurationURL":
+					return CFProxyType.AutoConfigurationUrl;
+				case "kCFProxyTypeAutoConfigurationJavaScript":
+					return CFProxyType.AutoConfigurationJavaScript;
+				case "kCFProxyTypeFTP":         
+					return CFProxyType.FTP;     
+				case "kCFProxyTypeHTTP":        
+					return CFProxyType.HTTP;    
+				case "kCFProxyTypeHTTPS":       
+					return CFProxyType.HTTPS;   
+				case "kCFProxyTypeSOCKS":       
+					return CFProxyType.SOCKS;   
+			}
+			
 			return CFProxyType.None;
 		}
 		


### PR DESCRIPTION
Reference comparison of kCFProxyTypeAutoConfigurationURL doesn't work in OSX 10.13. Added fallback to do value/string comparison to get proxy type.

In OSX 10.13, the IntPrt value for kCFProxyTypeKey in the dictionary returned by CFProxyAutoConfigurationResultCallback no longer match CFProxy.kCFProxyTypeAutoConfigurationURL .

My excerpt of my discovery code (altered code from CFNetwork.ExecuteProxyAutoConfigurationURL) :
```CSharp
        [DllImport(CFObject.CoreFoundationLibrary)]
        extern static void CFDictionaryGetKeysAndValues(IntPtr theDict, IntPtr[] keys, IntPtr[] values);

        [DllImport(CFObject.CoreFoundationLibrary)]
        extern static int CFDictionaryGetCount(IntPtr theDict);

...

           var proxyAutoConfigURL = CFUrl.Create("http://[url-to-doc-pac-file]");
            var targetURL = CFUrl.Create("http://[target-url]");

            CFProxy[] proxies = null;

            var runLoop = CFRunLoop.CurrentRunLoop;

            // Callback that will be called after executing the configuration script
            CFNetwork.CFProxyAutoConfigurationResultCallback cb = delegate (IntPtr client, IntPtr proxyList, IntPtr error)
            {
                Console.WriteLine("In Callback");
                if (proxyList != IntPtr.Zero)
                {
                    var array = new CFArray(proxyList, false);
                    proxies = new CFProxy[array.Count];
                    for (int i = 0; i < proxies.Length; i++)
                    {
                        CFDictionary dict = new CFDictionary(array[i], false);
                        var v = dict.GetValue(CFProxy.kCFProxyTypeKey);
                        Console.WriteLine($"kCFProxyTypeKey {CFString.AsString(v)}");
                        var count = CFDictionaryGetCount(dict.Handle);

                        var keys = new IntPtr[count];
                        var values = new IntPtr[count];
                        CFDictionaryGetKeysAndValues(dict.Handle, keys, values);

                        foreach(var k in keys) {
                            var keyStr = new CFString(k, false);
                            Console.WriteLine($"{keyStr}");
                        }

                        proxies[i] = new CFProxy(dict);
                    }
                    array.Dispose();
                }
                runLoop.Stop();
            };

            var clientContext = new CFStreamClientContext();
            var loopSource = CFNetwork.CFNetworkExecuteProxyAutoConfigurationURL(proxyAutoConfigURL.Handle, targetURL.Handle, cb, ref clientContext);

            // Create a private mode
            var mode = CFString.Create("Mono.MacProxy");

            runLoop.AddSource(loopSource, mode);
            runLoop.RunInMode(mode, double.MaxValue, false);
            runLoop.RemoveSource(loopSource, mode);

            foreach (var p in proxies)
            {
                Console.WriteLine($"{p.ProxyType} {p.HostName}");
            }
```